### PR TITLE
Bring over lowercase change from ublue-os/base

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,14 @@ jobs:
           tags: ${{ env.IMAGE_TAGS }}
           oci: true
        
+      # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
+      # https://github.com/macbre/push-to-ghcr/issues/12
+      - name: Lowercase Registry
+        id: registry_case
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ env.IMAGE_REGISTRY }}
+       
       # Push the image to GHCR (Image Registry)
       - name: Push To GHCR
         uses: redhat-actions/push-to-registry@v2
@@ -44,11 +52,12 @@ jobs:
         with:
           image: ${{ steps.build_image.outputs.image }}
           tags: ${{ steps.build_image.outputs.tags }}
-          registry: ${{ env.IMAGE_REGISTRY }}
+          registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
           extra-args: |
             --disable-content-trust
+
       # Sign container
       - uses: sigstore/cosign-installer@main
       - name: Login to GitHub Container Registry
@@ -59,7 +68,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Sign container image
         run: |
-          cosign sign ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@${TAGS}
+          cosign sign ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
         env:
           TAGS: ${{ steps.push.outputs.digest }}
           COSIGN_PRIVATE_KEY: ${{secrets.SIGNING_SECRET}}


### PR DESCRIPTION
Adjusts container signing to use the same lowercase URL

See: https://github.com/ublue-os/base/pull/1