### PR TITLE
chore: Containerfile Cleanup

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,6 @@
-FROM quay.io/fedora-ostree-desktops/silverblue:latest
+ARG FEDORA_MAJOR_VERSION=37
+
+FROM quay.io/fedora-ostree-desktops/silverblue:${FEDORA_MAJOR_VERSION}
 
 LABEL org.opencontainers.image.created=2022-06-27T00:00:00Z
 LABEL org.opencontainers.image.description="The description goes in here."

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,4 @@
-FROM ghcr.io/cgwalters/fedora-silverblue:37
-# See https://pagure.io/releng/issue/11047 for final location
+FROM quay.io/fedora-ostree-desktops/silverblue:latest
 
 LABEL org.opencontainers.image.created=2022-06-27T00:00:00Z
 LABEL org.opencontainers.image.description="The description goes in here."
@@ -8,16 +7,17 @@ LABEL io.artifacthub.package.logo-url="https://avatars.githubusercontent.com/u/1
 
 COPY etc /etc
 
-RUN rpm-ostree override remove firefox firefox-langpacks && \
-    rpm-ostree install distrobox gnome-tweaks vte291-gtk4-devel && \
+RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/vanilla-first-setup/repo/fedora-$(rpm -E %fedora)/ublue-os-vanilla-first-setup-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_ublue-os-vanilla-first-setup.repo && \
+    rpm-ostree override remove firefox firefox-langpacks && \
+    rpm-ostree install vanilla-first-setup distrobox gnome-tweaks vte291-gtk4-devel && \
     sed -i 's/#AutomaticUpdatePolicy.*/AutomaticUpdatePolicy=stage/' /etc/rpm-ostreed.conf && \
     systemctl enable rpm-ostreed-automatic.timer && \
-    systemctl enable flatpak-automatic.timer && \
+    systemctl enable flatpak-automatic.timer
+    
+# Cleanup
+RUN sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-vanilla-first-setup.repo && \
     rpm-ostree cleanup -m && \
-    ostree container commit
-
-# VanillaOS first-setup
-COPY --from=ghcr.io/adamisrael/vanilla-first-setup:latest /first-setup/vanilla-first-setup.tar.gz /tmp/vanilla-first-setup.tar.gz
-RUN tar xf /tmp/vanilla-first-setup.tar.gz --strip-component=1 -C / && \
-    chmod +x /usr/bin/vanilla-first-setup && \
+    rm -rf \
+        /tmp/* \
+        /var/* && \
     ostree container commit


### PR DESCRIPTION
Changes image source, adds vanilla-first-setup copr, disables copr repo and cleans /tmp/ and /var/ to match ublue-os/nvidia behavior